### PR TITLE
Integrate the Home screen with Home logic ✅

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,5 +30,8 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - unnecessary_const
+analyzer:
+  errors:
+    unused_element: ignore
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -1,6 +1,8 @@
 import 'package:dio/dio.dart';
 import 'package:doctor_reservation_app/core/networking/api_service.dart';
 import 'package:doctor_reservation_app/core/networking/dio_factory.dart';
+import 'package:doctor_reservation_app/features/home/data/api/home_api_service.dart';
+import 'package:doctor_reservation_app/features/home/data/repo/home_repo.dart';
 import 'package:doctor_reservation_app/features/login/data/repo/login_repo.dart';
 import 'package:doctor_reservation_app/features/login/logic/cubit/login_cubit.dart';
 import 'package:doctor_reservation_app/features/sign_up/data/repo/signup_repo.dart';
@@ -24,4 +26,7 @@ Future<void> setupGetIt() async {
   getIt.registerFactory<SignupCubit>(() => SignupCubit(getIt()));
 
   // home
+
+  getIt.registerLazySingleton<HomeApiService>(() => HomeApiService(dio));
+  getIt.registerLazySingleton<HomeRepo>(() => HomeRepo(getIt()));
 }

--- a/lib/core/networking/dio_factory.dart
+++ b/lib/core/networking/dio_factory.dart
@@ -13,10 +13,19 @@ class DioFactory {
         ..options.connectTimeout = timeOut
         ..options.receiveTimeout = timeOut;
       addDioInterceptor();
+      addDioHeader();
       return dio!;
     } else {
       return dio!;
     }
+  }
+
+  static void addDioHeader() {
+    dio?.options.headers = {
+      'Accept': 'application/json',
+      'Authorization':
+          'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3ZjYXJlLmludGVncmF0aW9uMjUuY29tL2FwaS9hdXRoL2xvZ2luIiwiaWF0IjoxNzY3ODkyOTM3LCJleHAiOjE3Njc5NzkzMzcsIm5iZiI6MTc2Nzg5MjkzNywianRpIjoiOGVzYkladVBZNXc4cDhVNSIsInN1YiI6IjYwMTAiLCJwcnYiOiIyM2JkNWM4OTQ5ZjYwMGFkYjM5ZTcwMWM0MDA4NzJkYjdhNTk3NmY3In0.-H_lvewym6eQ9aGL81xdCm_hsyZj5f_rhBQD7zEqXbQ'
+    };
   }
 
   static void addDioInterceptor() {

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:doctor_reservation_app/core/di/dependency_injection.dart';
 import 'package:doctor_reservation_app/core/routing/routes.dart';
+import 'package:doctor_reservation_app/features/home/logic/cubit/home_cubit.dart';
 import 'package:doctor_reservation_app/features/home/presentation/screens/home_screen.dart';
 import 'package:doctor_reservation_app/features/login/logic/cubit/login_cubit.dart';
 import 'package:doctor_reservation_app/features/login/presentation/screens/login_screen.dart';
@@ -10,7 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AppRouter {
-  Route onGenerateRoute(RouteSettings settings) {
+  Route? onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
       case Routes.onBoardingScreen:
         return MaterialPageRoute(
@@ -32,15 +33,14 @@ class AppRouter {
         );
       case Routes.homeScreen:
         return MaterialPageRoute(
-          builder: (context) => const HomeScreen(),
+          builder: (context) => BlocProvider(
+            create: (context) => HomeCubit(getIt())..getSpecilazation(),
+            child: const HomeScreen(),
+          ),
         );
 
       default:
-        return MaterialPageRoute(
-          builder: (_) => Scaffold(
-            body: Center(child: Text('No route found ${settings.name}')),
-          ),
-        );
+        return null;
     }
   }
 }

--- a/lib/core/widgets/custom_loading_indicator.dart
+++ b/lib/core/widgets/custom_loading_indicator.dart
@@ -1,0 +1,28 @@
+import 'package:doctor_reservation_app/core/theme/app_color.dart';
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/loading_animation_widget.dart';
+
+class CustomLoadingDialog extends StatelessWidget {
+  const CustomLoadingDialog({super.key, this.size});
+  final double? size;
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: Center(
+        child: LoadingAnimationWidget.staggeredDotsWave(
+          color: AppColor.primaryColor100,
+          size: size ?? 60,
+        ),
+      ),
+    );
+  }
+}
+
+void showLoadingDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => const CustomLoadingDialog(),
+  );
+}

--- a/lib/doc_app.dart
+++ b/lib/doc_app.dart
@@ -20,7 +20,7 @@ class DocApp extends StatelessWidget {
           primaryColor: AppColor.primaryColor100,
           scaffoldBackgroundColor: AppColor.whiteColor,
         ),
-        initialRoute: Routes.homeScreen,
+        initialRoute: Routes.onBoardingScreen,
         onGenerateRoute: appRouter.onGenerateRoute,
       ),
     );

--- a/lib/features/home/data/api/home_api_constant.dart
+++ b/lib/features/home/data/api/home_api_constant.dart
@@ -1,0 +1,3 @@
+class HomeApiConstant {
+  static const String specializationEndPoint = '/specialization/index';
+}

--- a/lib/features/home/data/api/home_api_service.dart
+++ b/lib/features/home/data/api/home_api_service.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+import 'package:doctor_reservation_app/core/networking/api_constant.dart';
+import 'package:doctor_reservation_app/features/home/data/api/home_api_constant.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'home_api_service.g.dart';
+
+@RestApi(baseUrl: ApiConstant.apiBaseUrl)
+abstract class HomeApiService {
+  factory HomeApiService(Dio dio, {String baseUrl}) = _HomeApiService;
+
+  @GET(HomeApiConstant.specializationEndPoint)
+  Future<SpecializationResponseModel> getSpecilazation();
+}

--- a/lib/features/home/data/api/home_api_service.g.dart
+++ b/lib/features/home/data/api/home_api_service.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_api_service.dart';
+
+// dart format off
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
+
+class _HomeApiService implements HomeApiService {
+  _HomeApiService(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??= 'https://vcare.integration25.com/api/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<SpecializationResponseModel> getSpecilazation() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<SpecializationResponseModel>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/specialization/index',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SpecializationResponseModel _value;
+    try {
+      _value = SpecializationResponseModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}
+
+// dart format on

--- a/lib/features/home/data/model/specialization_response_model.dart
+++ b/lib/features/home/data/model/specialization_response_model.dart
@@ -1,0 +1,49 @@
+import 'package:json_annotation/json_annotation.dart';
+part 'specialization_response_model.g.dart';
+
+@JsonSerializable()
+class SpecializationResponseModel {
+  @JsonKey(name: 'data')
+  List<SpecializationsData?>? specializationsData;
+  SpecializationResponseModel({this.specializationsData});
+  factory SpecializationResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$SpecializationResponseModelFromJson(json);
+}
+
+@JsonSerializable()
+class SpecializationsData {
+  int? id;
+  @JsonKey(name: 'name')
+  String? specialityCatgory;
+  @JsonKey(name: 'doctors')
+  List<DoctorsModel?>? doctorsModel;
+  SpecializationsData({this.id, this.specialityCatgory, this.doctorsModel});
+  factory SpecializationsData.fromJson(Map<String, dynamic> json) =>
+      _$SpecializationsDataFromJson(json);
+}
+
+@JsonSerializable()
+class DoctorsModel {
+  int? id;
+  String? name;
+  String? email;
+  String? phone;
+  String? photo;
+  String? gender;
+  String? degree;
+  @JsonKey(name: 'appoint_price')
+  int? price;
+  DoctorsModel({
+    this.id,
+    this.name,
+    this.email,
+    this.phone,
+    this.photo,
+    this.gender,
+    this.degree,
+    this.price,
+  });
+
+  factory DoctorsModel.fromJson(Map<String, dynamic> json) =>
+      _$DoctorsModelFromJson(json);
+}

--- a/lib/features/home/data/model/specialization_response_model.g.dart
+++ b/lib/features/home/data/model/specialization_response_model.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'specialization_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SpecializationResponseModel _$SpecializationResponseModelFromJson(
+        Map<String, dynamic> json) =>
+    SpecializationResponseModel(
+      specializationsData: (json['data'] as List<dynamic>?)
+          ?.map((e) => e == null
+              ? null
+              : SpecializationsData.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SpecializationResponseModelToJson(
+        SpecializationResponseModel instance) =>
+    <String, dynamic>{
+      'data': instance.specializationsData,
+    };
+
+SpecializationsData _$SpecializationsDataFromJson(Map<String, dynamic> json) =>
+    SpecializationsData(
+      id: (json['id'] as num?)?.toInt(),
+      specialityCatgory: json['name'] as String?,
+      doctorsModel: (json['doctors'] as List<dynamic>?)
+          ?.map((e) => e == null
+              ? null
+              : DoctorsModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SpecializationsDataToJson(
+        SpecializationsData instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.specialityCatgory,
+      'doctors': instance.doctorsModel,
+    };
+
+DoctorsModel _$DoctorsModelFromJson(Map<String, dynamic> json) => DoctorsModel(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+      email: json['email'] as String?,
+      phone: json['phone'] as String?,
+      photo: json['photo'] as String?,
+      gender: json['gender'] as String?,
+      degree: json['degree'] as String?,
+      price: (json['appoint_price'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$DoctorsModelToJson(DoctorsModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'email': instance.email,
+      'phone': instance.phone,
+      'photo': instance.photo,
+      'gender': instance.gender,
+      'degree': instance.degree,
+      'appoint_price': instance.price,
+    };

--- a/lib/features/home/data/repo/home_repo.dart
+++ b/lib/features/home/data/repo/home_repo.dart
@@ -1,0 +1,18 @@
+import 'package:doctor_reservation_app/core/networking/api_error_handler.dart';
+import 'package:doctor_reservation_app/core/networking/api_reuslt.dart';
+import 'package:doctor_reservation_app/features/home/data/api/home_api_service.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+
+class HomeRepo {
+  final HomeApiService _homeApiService;
+  HomeRepo(this._homeApiService);
+
+  Future<ApiReuslt<SpecializationResponseModel>> getSpecilazation() async {
+    try {
+      final response = await _homeApiService.getSpecilazation();
+      return ApiReuslt.success(response);
+    } catch (error) {
+      return ApiReuslt.failure(ErrorHandler.handle(error));
+    }
+  }
+}

--- a/lib/features/home/logic/cubit/home_cubit.dart
+++ b/lib/features/home/logic/cubit/home_cubit.dart
@@ -1,0 +1,23 @@
+import 'package:bloc/bloc.dart';
+import 'package:doctor_reservation_app/core/networking/api_reuslt.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:doctor_reservation_app/features/home/data/repo/home_repo.dart';
+import 'package:doctor_reservation_app/features/home/logic/cubit/home_state.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  final HomeRepo _homeRepo;
+  HomeCubit(this._homeRepo) : super(const HomeState.initial());
+
+  void getSpecilazation() async {
+    emit(const HomeState.specializationLoading());
+    final response = await _homeRepo.getSpecilazation();
+    response.when(
+      success: (SpecializationResponseModel specializationResponseModel) {
+        emit(HomeState.specializationSuccess(specializationResponseModel));
+      },
+      failure: (error) {
+        emit(HomeState.specializationFailure(error));
+      },
+    );
+  }
+}

--- a/lib/features/home/logic/cubit/home_state.dart
+++ b/lib/features/home/logic/cubit/home_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_state.freezed.dart';
+
+@freezed
+class HomeState<T> with _$HomeState<T> {
+  const factory HomeState.initial() = _Initial;
+  const factory HomeState.specializationLoading() = SpecializationLoading;
+  const factory HomeState.specializationSuccess(T specializationResponseModel) =
+      SpecializationSuccess;
+  const factory HomeState.specializationFailure(error) = SpecializationFailure;
+}

--- a/lib/features/home/logic/cubit/home_state.dart
+++ b/lib/features/home/logic/cubit/home_state.dart
@@ -1,3 +1,4 @@
+import 'package:doctor_reservation_app/core/networking/api_error_handler.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'home_state.freezed.dart';
@@ -8,5 +9,6 @@ class HomeState<T> with _$HomeState<T> {
   const factory HomeState.specializationLoading() = SpecializationLoading;
   const factory HomeState.specializationSuccess(T specializationResponseModel) =
       SpecializationSuccess;
-  const factory HomeState.specializationFailure(error) = SpecializationFailure;
+  const factory HomeState.specializationFailure(ErrorHandler error) =
+      SpecializationFailure;
 }

--- a/lib/features/home/logic/cubit/home_state.freezed.dart
+++ b/lib/features/home/logic/cubit/home_state.freezed.dart
@@ -1,0 +1,380 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'home_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$HomeState<T> {
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is HomeState<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'HomeState<$T>()';
+  }
+}
+
+/// @nodoc
+class $HomeStateCopyWith<T, $Res> {
+  $HomeStateCopyWith(HomeState<T> _, $Res Function(HomeState<T>) __);
+}
+
+/// Adds pattern-matching-related methods to [HomeState].
+extension HomeStatePatterns<T> on HomeState<T> {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(SpecializationLoading<T> value)? specializationLoading,
+    TResult Function(SpecializationSuccess<T> value)? specializationSuccess,
+    TResult Function(SpecializationFailure<T> value)? specializationFailure,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial() when initial != null:
+        return initial(_that);
+      case SpecializationLoading() when specializationLoading != null:
+        return specializationLoading(_that);
+      case SpecializationSuccess() when specializationSuccess != null:
+        return specializationSuccess(_that);
+      case SpecializationFailure() when specializationFailure != null:
+        return specializationFailure(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(SpecializationLoading<T> value)
+        specializationLoading,
+    required TResult Function(SpecializationSuccess<T> value)
+        specializationSuccess,
+    required TResult Function(SpecializationFailure<T> value)
+        specializationFailure,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial():
+        return initial(_that);
+      case SpecializationLoading():
+        return specializationLoading(_that);
+      case SpecializationSuccess():
+        return specializationSuccess(_that);
+      case SpecializationFailure():
+        return specializationFailure(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(SpecializationLoading<T> value)? specializationLoading,
+    TResult? Function(SpecializationSuccess<T> value)? specializationSuccess,
+    TResult? Function(SpecializationFailure<T> value)? specializationFailure,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial() when initial != null:
+        return initial(_that);
+      case SpecializationLoading() when specializationLoading != null:
+        return specializationLoading(_that);
+      case SpecializationSuccess() when specializationSuccess != null:
+        return specializationSuccess(_that);
+      case SpecializationFailure() when specializationFailure != null:
+        return specializationFailure(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? specializationLoading,
+    TResult Function(T specializationResponseModel)? specializationSuccess,
+    TResult Function()? specializationFailure,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial() when initial != null:
+        return initial();
+      case SpecializationLoading() when specializationLoading != null:
+        return specializationLoading();
+      case SpecializationSuccess() when specializationSuccess != null:
+        return specializationSuccess(_that.specializationResponseModel);
+      case SpecializationFailure() when specializationFailure != null:
+        return specializationFailure();
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() specializationLoading,
+    required TResult Function(T specializationResponseModel)
+        specializationSuccess,
+    required TResult Function() specializationFailure,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial():
+        return initial();
+      case SpecializationLoading():
+        return specializationLoading();
+      case SpecializationSuccess():
+        return specializationSuccess(_that.specializationResponseModel);
+      case SpecializationFailure():
+        return specializationFailure();
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? specializationLoading,
+    TResult? Function(T specializationResponseModel)? specializationSuccess,
+    TResult? Function()? specializationFailure,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Initial() when initial != null:
+        return initial();
+      case SpecializationLoading() when specializationLoading != null:
+        return specializationLoading();
+      case SpecializationSuccess() when specializationSuccess != null:
+        return specializationSuccess(_that.specializationResponseModel);
+      case SpecializationFailure() when specializationFailure != null:
+        return specializationFailure();
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Initial<T> implements HomeState<T> {
+  const _Initial();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Initial<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'HomeState<$T>.initial()';
+  }
+}
+
+/// @nodoc
+
+class SpecializationLoading<T> implements HomeState<T> {
+  const SpecializationLoading();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is SpecializationLoading<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'HomeState<$T>.specializationLoading()';
+  }
+}
+
+/// @nodoc
+
+class SpecializationSuccess<T> implements HomeState<T> {
+  const SpecializationSuccess(this.specializationResponseModel);
+
+  final T specializationResponseModel;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $SpecializationSuccessCopyWith<T, SpecializationSuccess<T>> get copyWith =>
+      _$SpecializationSuccessCopyWithImpl<T, SpecializationSuccess<T>>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SpecializationSuccess<T> &&
+            const DeepCollectionEquality().equals(
+                other.specializationResponseModel,
+                specializationResponseModel));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(specializationResponseModel));
+
+  @override
+  String toString() {
+    return 'HomeState<$T>.specializationSuccess(specializationResponseModel: $specializationResponseModel)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $SpecializationSuccessCopyWith<T, $Res>
+    implements $HomeStateCopyWith<T, $Res> {
+  factory $SpecializationSuccessCopyWith(SpecializationSuccess<T> value,
+          $Res Function(SpecializationSuccess<T>) _then) =
+      _$SpecializationSuccessCopyWithImpl;
+  @useResult
+  $Res call({T specializationResponseModel});
+}
+
+/// @nodoc
+class _$SpecializationSuccessCopyWithImpl<T, $Res>
+    implements $SpecializationSuccessCopyWith<T, $Res> {
+  _$SpecializationSuccessCopyWithImpl(this._self, this._then);
+
+  final SpecializationSuccess<T> _self;
+  final $Res Function(SpecializationSuccess<T>) _then;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? specializationResponseModel = freezed,
+  }) {
+    return _then(SpecializationSuccess<T>(
+      freezed == specializationResponseModel
+          ? _self.specializationResponseModel
+          : specializationResponseModel // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class SpecializationFailure<T> implements HomeState<T> {
+  const SpecializationFailure(errorHandle);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is SpecializationFailure<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'HomeState<$T>.specializationFailure()';
+  }
+}
+
+// dart format on

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:doctor_reservation_app/core/helpers/spacing.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_blue_banner.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_speciality_and_see_all_section.dart';
+import 'package:doctor_reservation_app/features/home/presentation/widget/home_screen_bloc_builder_widget.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/home_top_bar.dart';
 import 'package:flutter/material.dart';
 
@@ -21,9 +22,7 @@ class HomeScreen extends StatelessWidget {
             verticalSpace(24),
             const DoctorSpecialityAndSeeAllSection(),
             verticalSpace(20),
-            // const DoctorSpecialistSection(),
-            verticalSpace(12),
-            // const DoctorsListView(),
+            const HomeScreenBlocBuilderWidget(),
           ],
         ),
       )),

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,8 +1,6 @@
 import 'package:doctor_reservation_app/core/helpers/spacing.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_blue_banner.dart';
-import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_specialist_section.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_speciality_and_see_all_section.dart';
-import 'package:doctor_reservation_app/features/home/presentation/widget/doctors_list_view.dart';
 import 'package:doctor_reservation_app/features/home/presentation/widget/home_top_bar.dart';
 import 'package:flutter/material.dart';
 
@@ -23,9 +21,9 @@ class HomeScreen extends StatelessWidget {
             verticalSpace(24),
             const DoctorSpecialityAndSeeAllSection(),
             verticalSpace(20),
-            const DoctorSpecialistSection(),
+            // const DoctorSpecialistSection(),
             verticalSpace(12),
-            const DoctorsListView(),
+            // const DoctorsListView(),
           ],
         ),
       )),

--- a/lib/features/home/presentation/widget/doctor_specialist_item.dart
+++ b/lib/features/home/presentation/widget/doctor_specialist_item.dart
@@ -1,0 +1,35 @@
+import 'package:doctor_reservation_app/core/helpers/spacing.dart';
+import 'package:doctor_reservation_app/core/theme/app_color.dart';
+import 'package:doctor_reservation_app/core/theme/app_images.dart';
+import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+
+class DoctorSpecialistItem extends StatelessWidget {
+  const DoctorSpecialistItem(
+      {super.key, required this.itemIndex, this.specializationsData});
+  final int itemIndex;
+  final SpecializationsData? specializationsData;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsetsDirectional.only(start: itemIndex == 0 ? 0 : 24.w),
+      child: Column(
+        children: [
+          CircleAvatar(
+            radius: 28.r,
+            backgroundColor: AppColor.grayColor30,
+            child: SvgPicture.asset(AppImages.doctorIcon),
+          ),
+          verticalSpace(8),
+          Text(
+            specializationsData?.specialityCatgory ?? 'Genral',
+            style: TextStyles.font12Gray100Regular,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widget/doctor_specialist_section.dart
+++ b/lib/features/home/presentation/widget/doctor_specialist_section.dart
@@ -1,13 +1,15 @@
-import 'package:doctor_reservation_app/core/helpers/spacing.dart';
-import 'package:doctor_reservation_app/core/theme/app_color.dart';
-import 'package:doctor_reservation_app/core/theme/app_images.dart';
-import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_specialist_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 class DoctorSpecialistSection extends StatelessWidget {
-  const DoctorSpecialistSection({super.key});
+  final List<SpecializationsData?> specializationsData;
+  const DoctorSpecialistSection({
+    super.key,
+    required this.specializationsData,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -16,25 +18,12 @@ class DoctorSpecialistSection extends StatelessWidget {
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
         itemBuilder: (context, index) {
-          return Padding(
-            padding: EdgeInsetsDirectional.only(start: index == 0 ? 0 : 24.w),
-            child: Column(
-              children: [
-                CircleAvatar(
-                  radius: 28.r,
-                  backgroundColor: AppColor.grayColor30,
-                  child: SvgPicture.asset(AppImages.doctorIcon),
-                ),
-                verticalSpace(8),
-                Text(
-                  'General',
-                  style: TextStyles.font12Gray100Regular,
-                ),
-              ],
-            ),
+          return DoctorSpecialistItem(
+            specializationsData: specializationsData[index],
+            itemIndex: index,
           );
         },
-        itemCount: 10,
+        itemCount: specializationsData.length,
       ),
     );
   }

--- a/lib/features/home/presentation/widget/doctors_list_view.dart
+++ b/lib/features/home/presentation/widget/doctors_list_view.dart
@@ -1,64 +1,18 @@
-import 'package:doctor_reservation_app/core/helpers/spacing.dart';
-import 'package:doctor_reservation_app/core/theme/app_color.dart';
-import 'package:doctor_reservation_app/core/theme/app_images.dart';
-import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:doctor_reservation_app/features/home/presentation/widget/doctors_list_view_item.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class DoctorsListView extends StatelessWidget {
-  const DoctorsListView({super.key});
-
+  const DoctorsListView({super.key, required this.doctorsModel});
+  final List<DoctorsModel> doctorsModel;
   @override
   Widget build(BuildContext context) {
     return Expanded(
       child: ListView.builder(
-        itemCount: 10,
+        itemCount: doctorsModel.length,
         itemBuilder: (context, index) {
-          return Container(
-            margin: EdgeInsets.only(bottom: 16.h),
-            child: Row(
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(24),
-                  child: Container(
-                    decoration: const BoxDecoration(
-                      color: AppColor.grayColor20,
-                    ),
-                    child: Image.asset(
-                      width: 110.w,
-                      height: 120.h,
-                      AppImages.doctorCarton,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                ),
-                horizontalSpace(16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Dr. Randy Wigham',
-                        style: TextStyles.font16GrayColor100Bold,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      verticalSpace(5),
-                      Text(
-                        'General | 01149060781',
-                        style: TextStyles.font12Gray70Regular,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      verticalSpace(5),
-                      Text(
-                        'Email@gmail.com',
-                        style: TextStyles.font12Gray70Regular,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
+          return DoctorsListViewItem(
+            doctorsModel: doctorsModel[index],
           );
         },
       ),

--- a/lib/features/home/presentation/widget/doctors_list_view.dart
+++ b/lib/features/home/presentation/widget/doctors_list_view.dart
@@ -3,16 +3,16 @@ import 'package:doctor_reservation_app/features/home/presentation/widget/doctors
 import 'package:flutter/widgets.dart';
 
 class DoctorsListView extends StatelessWidget {
-  const DoctorsListView({super.key, required this.doctorsModel});
-  final List<DoctorsModel> doctorsModel;
+  const DoctorsListView({super.key, this.doctorsModel});
+  final List<DoctorsModel?>? doctorsModel;
   @override
   Widget build(BuildContext context) {
     return Expanded(
       child: ListView.builder(
-        itemCount: doctorsModel.length,
+        itemCount: doctorsModel?.length,
         itemBuilder: (context, index) {
           return DoctorsListViewItem(
-            doctorsModel: doctorsModel[index],
+            doctorsModel: doctorsModel?[index],
           );
         },
       ),

--- a/lib/features/home/presentation/widget/doctors_list_view_item.dart
+++ b/lib/features/home/presentation/widget/doctors_list_view_item.dart
@@ -1,0 +1,61 @@
+import 'package:doctor_reservation_app/core/helpers/spacing.dart';
+import 'package:doctor_reservation_app/core/theme/app_color.dart';
+import 'package:doctor_reservation_app/core/theme/app_images.dart';
+import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class DoctorsListViewItem extends StatelessWidget {
+  final DoctorsModel? doctorsModel;
+  const DoctorsListViewItem({super.key, this.doctorsModel});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 16.h),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(24),
+            child: Container(
+              decoration: const BoxDecoration(
+                color: AppColor.grayColor20,
+              ),
+              child: Image.asset(
+                width: 110.w,
+                height: 120.h,
+                AppImages.doctorCarton,
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          horizontalSpace(16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  doctorsModel?.name ?? "Mohamed Osama",
+                  style: TextStyles.font16GrayColor100Bold,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                verticalSpace(5),
+                Text(
+                  "${doctorsModel?.gender ?? "Male"} | ${doctorsModel?.phone ?? "+201149060781"}",
+                  style: TextStyles.font12Gray70Regular,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                verticalSpace(5),
+                Text(
+                  doctorsModel?.email ?? "wohamedosama@gmail.com",
+                  style: TextStyles.font12Gray70Regular,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widget/home_screen_bloc_builder_widget.dart
+++ b/lib/features/home/presentation/widget/home_screen_bloc_builder_widget.dart
@@ -1,4 +1,5 @@
 import 'package:doctor_reservation_app/core/helpers/spacing.dart';
+import 'package:doctor_reservation_app/core/widgets/custom_loading_indicator.dart';
 import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
 import 'package:doctor_reservation_app/features/home/logic/cubit/home_cubit.dart';
 import 'package:doctor_reservation_app/features/home/logic/cubit/home_state.dart';
@@ -19,7 +20,7 @@ class HomeScreenBlocBuilderWidget extends StatelessWidget {
           current is SpecializationFailure,
       builder: (context, state) {
         return state.maybeWhen(
-          specializationLoading: () => setupLoadingIndicator(),
+          specializationLoading: () => const CustomLoadingDialog(),
           specializationSuccess: (specializationResponseModel) =>
               setupSpecializationSuccess(specializationResponseModel),
           specializationFailure: () => setupError(),

--- a/lib/features/home/presentation/widget/home_screen_bloc_builder_widget.dart
+++ b/lib/features/home/presentation/widget/home_screen_bloc_builder_widget.dart
@@ -1,0 +1,63 @@
+import 'package:doctor_reservation_app/core/helpers/spacing.dart';
+import 'package:doctor_reservation_app/features/home/data/model/specialization_response_model.dart';
+import 'package:doctor_reservation_app/features/home/logic/cubit/home_cubit.dart';
+import 'package:doctor_reservation_app/features/home/logic/cubit/home_state.dart';
+import 'package:doctor_reservation_app/features/home/presentation/widget/doctor_specialist_section.dart';
+import 'package:doctor_reservation_app/features/home/presentation/widget/doctors_list_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class HomeScreenBlocBuilderWidget extends StatelessWidget {
+  const HomeScreenBlocBuilderWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HomeCubit, HomeState>(
+      buildWhen: (previous, current) =>
+          current is SpecializationLoading ||
+          current is SpecializationSuccess ||
+          current is SpecializationFailure,
+      builder: (context, state) {
+        return state.maybeWhen(
+          specializationLoading: () => setupLoadingIndicator(),
+          specializationSuccess: (specializationResponseModel) =>
+              setupSpecializationSuccess(specializationResponseModel),
+          specializationFailure: () => setupError(),
+          orElse: () {
+            return const SizedBox.shrink();
+          },
+        );
+      },
+    );
+  }
+
+  Widget setupSpecializationSuccess(
+      SpecializationResponseModel specializationResponseModel) {
+    var specializationsList = specializationResponseModel.specializationsData;
+    return Expanded(
+      child: Column(
+        children: [
+          DoctorSpecialistSection(
+              specializationsData: specializationsList ?? []),
+          verticalSpace(12),
+          DoctorsListView(
+            doctorsModel: specializationsList?[0]?.doctorsModel,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Widget setupError() {
+  return const SizedBox.shrink();
+}
+
+Widget setupLoadingIndicator() {
+  return const SizedBox(
+    height: 100,
+    child: Center(
+      child: CircularProgressIndicator(),
+    ),
+  );
+}

--- a/lib/features/login/data/model/login_request_body.g.dart
+++ b/lib/features/login/data/model/login_request_body.g.dart
@@ -1,7 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_element
-
 part of 'login_request_body.dart';
 
 // **************************************************************************

--- a/lib/features/login/data/model/login_response.g.dart
+++ b/lib/features/login/data/model/login_response.g.dart
@@ -1,7 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_element
-
 part of 'login_response.dart';
 
 // **************************************************************************

--- a/lib/features/login/presentation/widgets/build_bloc_listner.dart
+++ b/lib/features/login/presentation/widgets/build_bloc_listner.dart
@@ -3,6 +3,7 @@ import 'package:doctor_reservation_app/core/helpers/flutter_toast.dart';
 import 'package:doctor_reservation_app/core/routing/routes.dart';
 import 'package:doctor_reservation_app/core/theme/app_color.dart';
 import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+import 'package:doctor_reservation_app/core/widgets/custom_loading_indicator.dart';
 import 'package:doctor_reservation_app/features/login/logic/cubit/login_cubit.dart';
 import 'package:doctor_reservation_app/features/login/logic/cubit/login_state.dart';
 import 'package:flutter/material.dart';
@@ -16,9 +17,7 @@ class BuildBlocListner extends StatelessWidget {
     return BlocListener<LoginCubit, LoginState>(
       listener: (context, state) {
         state.whenOrNull(
-          loading: () {
-            showLoadingState(context);
-          },
+          loading: () => showLoadingDialog(context),
           success: (loginResponse) {
             context.pop();
             FlutterToast.showFlutterToast(

--- a/lib/features/sign_up/data/model/signup_response.g.dart
+++ b/lib/features/sign_up/data/model/signup_response.g.dart
@@ -1,7 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unused_element
-
 part of 'signup_response.dart';
 
 // **************************************************************************

--- a/lib/features/sign_up/presentation/widget/signup_bloc_lisnter.dart
+++ b/lib/features/sign_up/presentation/widget/signup_bloc_lisnter.dart
@@ -3,6 +3,7 @@ import 'package:doctor_reservation_app/core/helpers/flutter_toast.dart';
 import 'package:doctor_reservation_app/core/routing/routes.dart';
 import 'package:doctor_reservation_app/core/theme/app_color.dart';
 import 'package:doctor_reservation_app/core/theme/text_styles.dart';
+import 'package:doctor_reservation_app/core/widgets/custom_loading_indicator.dart';
 import 'package:doctor_reservation_app/features/sign_up/logic/cubit/signup_cubit.dart';
 import 'package:doctor_reservation_app/features/sign_up/logic/cubit/signup_state.dart';
 import 'package:flutter/material.dart';
@@ -16,7 +17,7 @@ class SignupBlocLisnter extends StatelessWidget {
     return BlocListener<SignupCubit, SignupState>(
       listener: (context, state) {
         state.whenOrNull(
-          loading: () => showLoadingState(context),
+          loading: () => showLoadingDialog(context),
           success: (date) => {
             context.pop(),
             FlutterToast.showFlutterToast(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,6 +493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  loading_animation_widget:
+    dependency: "direct main"
+    description:
+      name: loading_animation_widget
+      sha256: "9fe23381f3096e902f39e87e487648ff7f74925e86234353fa885bb9f6c98004"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,8 @@ dependencies:
   #Toast Library for Flutter, Easily create toast messages in single line of code
   fluttertoast: ^9.0.0
   firebase_core: ^4.3.0
+  # Loading animation or loading spiner or loader. It's used to show loading animation when the app is in loading state or something is processing for uncertain time.
+  loading_animation_widget: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🏗️ Home Screen Logic — Clean Architecture & Dynamic Data

### ✨ Overview
This update brings the **Home Screen business logic to life** using **BLoC/Cubit** and full API integration. The screen now fetches and displays real **specializations and doctors data**, following Clean Architecture principles with clear separation between presentation, logic, and data layers.

### 🚀 What’s New

#### 🧠 Business Logic Layer
- **HomeCubit**
  - Manages Home Screen states
  - Fetches specializations via `getSpecilazation()`
  - Handles loading, success, and error scenarios

- **HomeState (Freezed)**
  - `initial()` – Default state
  - `specializationLoading()` – API loading state
  - `specializationSuccess(data)` – Success with API data
  - `specializationFailure(error)` – Failure with detailed error handling

#### 📡 Data Layer
- **HomeRepo**
  - Repository pattern implementation
  - Centralized API and error handling
  - Returns `ApiResult<T>` for type-safe responses

- **HomeApiService**
  - Retrofit-based API service
  - Endpoint: `GET /specialization/index`
  - Auto-generated implementation via code generation

- **Data Models**
  - `SpecializationResponseModel`
  - `SpecializationsData` (id, name, doctors list)
  - `DoctorsModel` (id, name, email, phone, photo, gender, degree, price)
  - Fully null-safe with JSON serialization

#### 🎨 Presentation Layer Updates
- **HomeScreenBlocBuilderWidget**
  - Reacts to Cubit state changes
  - Loading → CustomLoadingDialog
  - Success → Specializations & Doctors UI
  - Failure → Error UI (currently minimal)
  - Optimized using `buildWhen`

- **Updated & New Widgets**
  - DoctorSpecialistSection (dynamic specialization data)
  - DoctorSpecialistItem (new)
  - DoctorsListView (dynamic doctors list)
  - DoctorsListViewItem (new)

#### 🔧 Configuration & Integration
- **AppRouter**
  - Injects HomeCubit using BlocProvider
  - Automatically triggers `getSpecilazation()` on screen load

- **Dependency Injection (GetIt)**
  - HomeApiService registered as lazy singleton
  - HomeRepo registered as lazy singleton
  - Clean and scalable DI setup

### 🏛️ Architecture Overview
Presentation → Business Logic → Data  
UI reacts to Cubit state, Cubit communicates with Repository, Repository calls API service.

### 📂 File Structure
lib/features/home/
├── data/
│   ├── api/
│   ├── model/
│   └── repo/
├── logic/
│   └── cubit/
└── presentation/
    ├── screens/
    └── widget/

### 📸 Screenshot
<img src="https://github.com/user-attachments/assets/2cee8330-0f33-42f3-acc3-1cff29edc83b" width="250" />

### 🔑 Key Highlights
- Freezed-based immutable state management
- Strong error handling with ErrorHandler
- Retrofit + JSON code generation
- Type-safe API responses
- Clean Architecture compliance
- Fully dynamic UI powered by backend data

### 📝 Notes
- Doctors are currently displayed from the first specialization only
- Error UI is minimal and can be enhanced in future PRs
- Fully integrated with existing theme and networking layers
